### PR TITLE
Increases version number to 0.7.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag=py33
+python-tag=py34

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.7.3',
+    version='0.7.4',
 
     description='A dependency injection system for python',
     long_description=long_description,


### PR DESCRIPTION
This should have been done before the v0.7.4 tagging and release.

Also updates `setup.cfg` to specify Python 3.4 requirement, to match `setup.py`.
