### PR TITLE
Add unit tests for ResourceProviderRegister

### DIFF
--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -45,11 +45,11 @@ class Test_ResourceProviderRegister__construction:
     def test__after_creation__namespace_should_default_to_None(self):
         instance = ResourceProviderRegister()
         assert instance.namespace is None
-    
+
     def test__after_creation_with_namespace__namespace_should_be_as_given(self):
         instance = ResourceProviderRegister('mynamespace')
         assert instance.namespace == 'mynamespace'
-        
+
     def test__after_creation__resource_providers_should_be_empty(self):
         instance = ResourceProviderRegister()
         assert len(instance.resource_providers) == 0

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -20,3 +20,22 @@ class Test_ResourceProviderRegister__construction:
     def test__after_creation_with_namespace__resource_providers_should_be_empty(self):
         instance = ResourceProviderRegister('mynamespace')
         assert len(instance.resource_providers) == 0
+
+class Test_ResourceProviderRegister_clear:
+
+    def test__with_empty_resource_providers__should_be_empty_after(self):
+        instance = ResourceProviderRegister()
+        instance.resource_providers = {}
+
+        instance.clear()
+        assert len(instance.resource_providers) == 0
+
+    def test__with_resources_in_resource_providers__should_be_empty_after(self):
+        instance = ResourceProviderRegister()
+        instance.resource_providers = {
+            'myresource': 'my value',
+            'mycallable': lambda x: x,
+        }
+
+        instance.clear()
+        assert len(instance.resource_providers) == 0

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -3,6 +3,8 @@ import functools
 import unittest.mock
 import pytest
 
+from fang.errors import ProviderAlreadyRegisteredError
+
 # Class under test:
 from fang.resource_provider_register import ResourceProviderRegister
 
@@ -124,5 +126,38 @@ class Test_ResourceProviderRegister_register:
 
         result = ResourceProviderRegister.register(
                 mock_instance, resource_name, resource_provider)
+
+        assert mock_instance.resource_providers[resource_name] == resource_provider
+
+    def test__giving_provider_already_registered__should_raise(
+            self, mock_instance, resource_name, resource_provider):
+
+        ResourceProviderRegister.register(
+                mock_instance, resource_name, resource_provider)
+
+        with pytest.raises(ProviderAlreadyRegisteredError):
+            ResourceProviderRegister.register(
+                    mock_instance, resource_name, resource_provider)
+
+    def test__giving_provider_already_registered_and_override_false__should_raise(
+            self, mock_instance, resource_name, resource_provider):
+
+        ResourceProviderRegister.register(
+                mock_instance, resource_name, resource_provider)
+
+        with pytest.raises(ProviderAlreadyRegisteredError):
+            ResourceProviderRegister.register(
+                    mock_instance, resource_name, resource_provider,
+                    allow_override=False)
+
+    def test__giving_provider_already_registered_and_override_true__should_register(
+            self, mock_instance, resource_name, resource_provider):
+
+        ResourceProviderRegister.register(
+                mock_instance, resource_name, resource_provider)
+
+        ResourceProviderRegister.register(
+                mock_instance, resource_name, resource_provider,
+                allow_override=True)
 
         assert mock_instance.resource_providers[resource_name] == resource_provider

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -18,6 +18,14 @@ def mock_instance():
 def resource_name():
     return 'test.resource'
 
+def give_unexpected_calls(method_calls, expected_methods_names):
+    '''
+
+    TODO: Move this to a common test utils module.
+    '''
+    return [call for call in method_calls
+            if call[0] not in expected_methods_names]
+
 class Test_ResourceProviderRegister__construction:
 
     def test__after_creation__namespace_should_default_to_None(self):
@@ -56,6 +64,13 @@ class Test_ResourceProviderRegister_clear:
         assert len(instance.resource_providers) == 0
 
 class Test_ResourceProviderRegister_register:
+    '''
+    Test the instance method ResourceProviderRegister.register().
+
+    NOTE: In these tests we call the method on the class, not the
+    instance, so we can give a mock instance in place of self. This
+    lets us check if register() calls any other instance methods.
+    '''
 
     def test__giving_no_provider_arg___should_return_partial(
             self, mock_instance, resource_name):
@@ -64,8 +79,6 @@ class Test_ResourceProviderRegister_register:
         register() should return a partial of register() with the
         resource_name argument fixed.
 
-        NOTE: In this test we call the method on the class, not an
-        instance, so we can give a mock instance for self.
         '''
         result = ResourceProviderRegister.register(
                 mock_instance, resource_name)
@@ -73,3 +86,23 @@ class Test_ResourceProviderRegister_register:
         assert isinstance(result, functools.partial)
         assert result.func == mock_instance.register
         assert result.args == (resource_name,)
+
+    def test__giving_no_provider_arg__should_not_call_any_other_methods(
+            self, mock_instance, resource_name):
+        '''
+        If register() is called with resource_name but no provider,
+        no other instance methods should be called.
+        '''
+
+        result = ResourceProviderRegister.register(
+                mock_instance, resource_name)
+
+        unexpected_calls = give_unexpected_calls(
+                mock_instance.method_calls, [])
+
+        assert not unexpected_calls, (
+                'Unexpected methods called: {!r} \n'
+                'Called methods: {!r} \n'
+                'No method calls were expected'.format(
+                unexpected_calls,
+                mock_DependenyRegister_instance.method_calls))

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -254,3 +254,96 @@ class Test_ResourceProviderRegister_register_instance:
         assert method == 'register', "resource() should have been called"
         assert kwargs['a'] == 'b'
         assert kwargs['c'] == 'd'
+
+class Test_ResourceProviderRegister_mass_register:
+
+    def test__giving_empty_dict__should_not_call_other_methods(
+            self, mock_instance):
+        '''
+        If mass_register() is called with an empty dict, no other
+        instance methods should be called.
+        '''
+        result = ResourceProviderRegister.mass_register(mock_instance, {})
+
+        unexpected_calls = give_unexpected_calls(
+                mock_instance.method_calls, [])
+
+        assert not unexpected_calls, (
+                'Unexpected methods called: {!r} \n'
+                'Called methods: {!r} \n'
+                'No method calls were expected'.format(
+                unexpected_calls,
+                mock_instance.method_calls))
+
+    def test__giving_empty_dict__should_return_None(
+            self, mock_instance):
+        '''
+        If mass_register() is called with an empty dict, it should
+        return None.
+        '''
+        result = ResourceProviderRegister.mass_register(mock_instance, {})
+        assert result is None
+
+    def test__giving_name_and_resource__should_call_register_instance(
+            self, mock_instance, resource_name, resource):
+        result = ResourceProviderRegister.mass_register(
+                mock_instance, {resource_name: resource})
+
+        assert len(mock_instance.method_calls) == 1
+        assert ('register_instance', (resource_name, resource), {}
+                ) in mock_instance.method_calls
+
+    def test__giving_name_and_resource__should_return_None(
+            self, mock_instance, resource_name, resource):
+        result = ResourceProviderRegister.mass_register(
+                mock_instance, {resource_name: resource})
+        assert result is None
+
+    def test__giving_n_names_and_resources__should_call_register_instance_n_times(
+            self, mock_instance):
+        result = ResourceProviderRegister.mass_register(
+                mock_instance,
+                {
+                    'test.resource.name.1': 'resource1',
+                    'test.resource.name.2': 'resource2',
+                    'test.resource.name.3': 'resource3',
+                })
+
+        assert len(mock_instance.method_calls) == 3
+        assert ('register_instance', ('test.resource.name.1', 'resource1'), {}
+                ) in mock_instance.method_calls
+        assert ('register_instance', ('test.resource.name.2', 'resource2'), {}
+                ) in mock_instance.method_calls
+        assert ('register_instance', ('test.resource.name.3', 'resource3'), {}
+                ) in mock_instance.method_calls
+
+    def test__giving_n_names_and_resources__should_return_None(
+            self, mock_instance):
+        result = ResourceProviderRegister.mass_register(
+                mock_instance,
+                {
+                    'test.resource.name.1': 'resource1',
+                    'test.resource.name.2': 'resource2',
+                    'test.resource.name.3': 'resource3',
+                })
+        assert result is None
+
+    def test__giving_kwargs__should_call_register_instance_with_kwargs(
+            self, mock_instance):
+
+        given_kwargs = dict(a=1, b=2)
+
+        result = ResourceProviderRegister.mass_register(
+                mock_instance,
+                {
+                    'test.resource.name.1': 'resource1',
+                    'test.resource.name.2': 'resource2',
+                    'test.resource.name.3': 'resource3',
+                },
+                **given_kwargs)
+
+        for call in mock_instance.method_calls:
+            method, args, kwargs = call
+            assert kwargs == given_kwargs, (
+                    '{!r} should have had keyword arguments {!r}'.format(
+                        call, given_kwargs))

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -1,0 +1,22 @@
+
+
+# Class under test:
+from fang.resource_provider_register import ResourceProviderRegister
+
+class Test_ResourceProviderRegister__construction:
+
+    def test__after_creation__namespace_should_default_to_None(self):
+        instance = ResourceProviderRegister()
+        assert instance.namespace is None
+    
+    def test__after_creation_with_namespace__namespace_should_be_as_given(self):
+        instance = ResourceProviderRegister('mynamespace')
+        assert instance.namespace == 'mynamespace'
+        
+    def test__after_creation__resource_providers_should_be_empty(self):
+        instance = ResourceProviderRegister()
+        assert len(instance.resource_providers) == 0
+
+    def test__after_creation_with_namespace__resource_providers_should_be_empty(self):
+        instance = ResourceProviderRegister('mynamespace')
+        assert len(instance.resource_providers) == 0

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -1,7 +1,22 @@
 
+import functools
+import unittest.mock
+import pytest
 
 # Class under test:
 from fang.resource_provider_register import ResourceProviderRegister
+
+@pytest.fixture()
+def mock_instance():
+    mock_instance = unittest.mock.NonCallableMock(
+            spec=ResourceProviderRegister())
+    mock_instance.dependents = {}
+    mock_instance.resources = {}
+    return mock_instance
+
+@pytest.fixture()
+def resource_name():
+    return 'test.resource'
 
 class Test_ResourceProviderRegister__construction:
 
@@ -39,3 +54,22 @@ class Test_ResourceProviderRegister_clear:
 
         instance.clear()
         assert len(instance.resource_providers) == 0
+
+class Test_ResourceProviderRegister_register:
+
+    def test__giving_no_provider_arg___should_return_partial(
+            self, mock_instance, resource_name):
+        '''
+        If register() is called with resource_name but no provider,
+        register() should return a partial of register() with the
+        resource_name argument fixed.
+
+        NOTE: In this test we call the method on the class, not an
+        instance, so we can give a mock instance for self.
+        '''
+        result = ResourceProviderRegister.register(
+                mock_instance, resource_name)
+
+        assert isinstance(result, functools.partial)
+        assert result.func == mock_instance.register
+        assert result.args == (resource_name,)

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -84,7 +84,7 @@ class Test_ResourceProviderRegister_register:
     lets us check if register() calls any other instance methods.
     '''
 
-    def test__giving_no_provider_arg___should_return_partial(
+    def test__giving_no_provider__should_return_partial(
             self, mock_instance, resource_name):
         '''
         If register() is called with resource_name but no provider,
@@ -99,7 +99,7 @@ class Test_ResourceProviderRegister_register:
         assert result.func == mock_instance.register
         assert result.args == (resource_name,)
 
-    def test__giving_no_provider_arg__should_not_call_any_other_methods(
+    def test__giving_no_provider__should_not_call_any_other_methods(
             self, mock_instance, resource_name):
         '''
         If register() is called with resource_name but no provider,

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -10,13 +10,25 @@ from fang.resource_provider_register import ResourceProviderRegister
 def mock_instance():
     mock_instance = unittest.mock.NonCallableMock(
             spec=ResourceProviderRegister())
-    mock_instance.dependents = {}
-    mock_instance.resources = {}
+    mock_instance.namespace = None
+    mock_instance.resource_providers = {}
     return mock_instance
 
 @pytest.fixture()
 def resource_name():
     return 'test.resource'
+
+@pytest.fixture()
+def resource():
+    def fake_resource(x):
+        return x
+    return fake_resource
+
+@pytest.fixture()
+def resource_provider(resource):
+    def fake_resource_provider():
+        return resource
+    return fake_resource_provider
 
 def give_unexpected_calls(method_calls, expected_methods_names):
     '''
@@ -106,3 +118,11 @@ class Test_ResourceProviderRegister_register:
                 'No method calls were expected'.format(
                 unexpected_calls,
                 mock_DependenyRegister_instance.method_calls))
+
+    def test__giving_provider__should_register_under_name(
+            self, mock_instance, resource_name, resource_provider):
+
+        result = ResourceProviderRegister.register(
+                mock_instance, resource_name, resource_provider)
+
+        assert mock_instance.resource_providers[resource_name] == resource_provider

--- a/tests/unit/test_resource_provider_register.py
+++ b/tests/unit/test_resource_provider_register.py
@@ -3,7 +3,8 @@ import functools
 import unittest.mock
 import pytest
 
-from fang.errors import FangError, ProviderAlreadyRegisteredError
+from fang.errors import (
+        FangError, ProviderAlreadyRegisteredError, ProviderNotFoundError)
 
 # Class under test:
 from fang.resource_provider_register import ResourceProviderRegister
@@ -461,3 +462,17 @@ class Test_ResourceProviderRegister_load:
                 'test.resource.name.2': 'new resource',
                 'test.resource.name.3': 'new resource',
         }, 'resource_providers should have been overriden with new resources'
+
+class Test_ResourceProviderRegister_resolve:
+
+    def test__given_known_resource_name__should_resolve_provider(
+            self, mock_instance, resource_name, resource, resource_provider):
+        mock_instance.resource_providers = {resource_name: resource_provider}
+
+        result = ResourceProviderRegister.resolve(mock_instance, resource_name)
+
+        assert result == resource
+
+    def test__given_unknown_resource_name__should_raise(self, mock_instance):
+        with pytest.raises(ProviderNotFoundError):
+            ResourceProviderRegister.resolve(mock_instance, 'unknown.resource')


### PR DESCRIPTION
Adds unit tests in new file `tests/unit/test_resource_provider_register.py`. These all test `ResourceProviderRegister` in the `fang.resource_provider_register` module.
